### PR TITLE
Add two photos upload

### DIFF
--- a/python-app/components/database.py
+++ b/python-app/components/database.py
@@ -74,7 +74,7 @@ async def add_item(pool, state, user_id):
                 data['email'],
                 data['birthday'],
                 [data['product']],
-                [data['photo']],
+                data['photo'],
                 [data['lucky_ticket']],
                 user_id
             )

--- a/python-app/components/database.py
+++ b/python-app/components/database.py
@@ -1,6 +1,7 @@
 import asyncpg
 
 from datetime import date
+import logging
 from dotenv import load_dotenv
 import os
 load_dotenv()
@@ -54,7 +55,7 @@ async def cmd_start_db(pool, user_id):
             await conn.execute("INSERT INTO users (tg_id) VALUES ($1)", user_id)
 
 
-async def add_item(pool, state, user_id):
+async def add_item(pool, state, shared_data, user_id):
     async with pool.acquire() as conn:
         async with state.proxy() as data:
             await conn.execute(
@@ -74,13 +75,13 @@ async def add_item(pool, state, user_id):
                 data['email'],
                 data['birthday'],
                 [data['product']],
-                data['photos'],
+                shared_data['photos'],
                 [data['lucky_ticket']],
                 user_id
             )
 
 
-async def additional_item(pool, state, user_id):
+async def additional_item(pool, state, shared_data, user_id):
     async with pool.acquire() as conn:
         async with state.proxy() as data:
             await conn.execute(
@@ -92,7 +93,7 @@ async def additional_item(pool, state, user_id):
                 WHERE tg_id = $4
                 """,
                 [data['product']],
-                data['photos'],
+                shared_data['photos'],
                 [data['lucky_ticket']],
                 user_id
             )

--- a/python-app/components/database.py
+++ b/python-app/components/database.py
@@ -74,7 +74,7 @@ async def add_item(pool, state, user_id):
                 data['email'],
                 data['birthday'],
                 [data['product']],
-                data['photo'],
+                data['photos'],
                 [data['lucky_ticket']],
                 user_id
             )
@@ -92,7 +92,7 @@ async def additional_item(pool, state, user_id):
                 WHERE tg_id = $4
                 """,
                 [data['product']],
-                [data['photo']],
+                data['photos'],
                 [data['lucky_ticket']],
                 user_id
             )

--- a/python-app/handlers/advanced.py
+++ b/python-app/handlers/advanced.py
@@ -73,27 +73,21 @@ async def add_photo_to_queue(file_id: str, message: types.Message, state: FSMCon
     """
     Добавляет фото в очередь, проверяет лимит и выполняет финализацию.
     """
-    async with state.proxy() as data:
-        # Инициализируем очередь и сохранённые ссылки
-        if 'photos' not in data:
-            data['photos'] = []
+    # Проверяем лимит
+    if len(shared_data['photos']) >= MAX_PHOTOS:
+        logging.warning(f"Лимит фото достигнут. Игнорируем фото: {file_id}")
+        return
 
-        # Проверяем лимит
-        if len(shared_data['photos']) >= MAX_PHOTOS:
-            logging.warning(f"Лимит фото достигнут. Игнорируем фото: {file_id}")
-            return
+    # Добавляем фото и сохраняем
+    logging.info(f"Добавляем фото: {file_id}")
+    photo_url = await save_photo_to_storage(file_id, message)
+    shared_data['photos'].append(photo_url)
 
-        # Добавляем фото и сохраняем
-        logging.info(f"Добавляем фото: {file_id}")
-        photo_url = await save_photo_to_storage(file_id, message)
-        shared_data['photos'].append(photo_url)
-
-        if len(shared_data['photos']) == 1:
-            await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
-        elif len(shared_data['photos']) == MAX_PHOTOS:
-            await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
-            data['photos'] = shared_data['photos']
-            await finalize_photos(message, state, data)
+    if len(shared_data['photos']) == 1:
+        await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
+    elif len(shared_data['photos']) == MAX_PHOTOS:
+        await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
+        await finalize_photos(message, state)
 
 
 async def save_photo_to_storage(file_id: str, message: types.Message) -> str:
@@ -107,12 +101,12 @@ async def save_photo_to_storage(file_id: str, message: types.Message) -> str:
     return photo_url
 
 
-async def finalize_photos(message: types.Message, state: FSMContext, data: dict):
+async def finalize_photos(message: types.Message, state: FSMContext):
     """
     Завершает обработку после сохранения двух фото.
     """
     await message.answer("🎉 Спасибо! Обе фотографии загружены и сохранены.")
-    logging.info(f"Финализированные фото: {data['photos']}")
+    logging.info(f"Финализированные фото: {shared_data['photos']}")
     await additional_lucky_ticket(message, state)
 
 
@@ -128,7 +122,7 @@ async def additional_lucky_ticket(message: types.Message, state: FSMContext):
     )
     async with state.proxy() as data:
         data['lucky_ticket'] = random_string
-    await db.additional_item(pool, state, message.from_user.id)
+    await db.additional_item(pool, state, shared_data, message.from_user.id)
     await botStages.UserAdvancedScreenplay.advanced.set()
     await advanced_stage(message)
 

--- a/python-app/handlers/advanced.py
+++ b/python-app/handlers/advanced.py
@@ -15,6 +15,7 @@ import random
 import string
 
 MAX_PHOTOS = 2
+shared_data = {"photos": []}
 state_lock = asyncio.Lock()
 
 
@@ -78,19 +79,20 @@ async def add_photo_to_queue(file_id: str, message: types.Message, state: FSMCon
             data['photos'] = []
 
         # Проверяем лимит
-        if len(data['photos']) >= MAX_PHOTOS:
+        if len(shared_data['photos']) >= MAX_PHOTOS:
             logging.warning(f"Лимит фото достигнут. Игнорируем фото: {file_id}")
             return
 
         # Добавляем фото и сохраняем
         logging.info(f"Добавляем фото: {file_id}")
         photo_url = await save_photo_to_storage(file_id, message)
-        data['photos'].append(photo_url)
+        shared_data['photos'].append(photo_url)
 
-        if len(data['photos']) == 1:
+        if len(shared_data['photos']) == 1:
             await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
-        elif len(data['photos']) == MAX_PHOTOS:
+        elif len(shared_data['photos']) == MAX_PHOTOS:
             await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
+            data['photos'] = shared_data['photos']
             await finalize_photos(message, state, data)
 
 

--- a/python-app/handlers/advanced.py
+++ b/python-app/handlers/advanced.py
@@ -85,9 +85,9 @@ async def add_photo_to_queue(file_id: str, message: types.Message, state: FSMCon
     shared_data['photos'].append(photo_url)
 
     current_state = await state.get_state()
-    if (len(shared_data['photos']) == 1) and (current_state == botStages.UserAdvancedScreenplay.advanced_photo):
+    if (len(shared_data['photos']) == 1) and (current_state == botStages.UserAdvancedScreenplay.advanced_photo.state):
         await message.answer("✅ Поздравляю, первая фотография сохранена!")
-    elif (len(shared_data['photos']) == MAX_PHOTOS) and (current_state == botStages.UserAdvancedScreenplay.advanced_photo):
+    elif (len(shared_data['photos']) == MAX_PHOTOS) and (current_state == botStages.UserAdvancedScreenplay.advanced_photo.state):
         await message.answer("✅ Поздравляю, ваша вторая фотография сохранена!")
         await finalize_photos(message, state)
 
@@ -126,7 +126,6 @@ async def additional_lucky_ticket(message: types.Message, state: FSMContext):
         f'Поздравляю, ваш отзыв зарегистрирован!\n'
         f'Номер вашего счастливого купона: {random_string}'
     )
-    await botStages.UserAdvancedScreenplay.advanced.set()
     await advanced_stage(message)
 
 

--- a/python-app/handlers/advanced.py
+++ b/python-app/handlers/advanced.py
@@ -158,5 +158,4 @@ def register_advanced_handlers(dp: Dispatcher):
     dp.register_message_handler(additional_product, state=botStages.UserAdvancedScreenplay.advanced_product)
     dp.register_message_handler(additional_photo, state=botStages.UserAdvancedScreenplay.advanced_photo,
                                 content_types=types.ContentType.PHOTO)
-    dp.register_message_handler(additional_lucky_ticket, state=botStages.UserAdvancedScreenplay.advanced_lucky_ticket)
     dp.register_message_handler(advanced_stage, state=botStages.UserAdvancedScreenplay.advanced)

--- a/python-app/handlers/advanced.py
+++ b/python-app/handlers/advanced.py
@@ -84,9 +84,9 @@ async def add_photo_to_queue(file_id: str, message: types.Message, state: FSMCon
     shared_data['photos'].append(photo_url)
 
     if len(shared_data['photos']) == 1:
-        await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
+        await message.answer("✅ Поздравляю, первая фотография сохранена!")
     elif len(shared_data['photos']) == MAX_PHOTOS:
-        await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
+        await message.answer("✅ Поздравляю, ваша вторая фотография сохранена!")
         await finalize_photos(message, state)
 
 

--- a/python-app/handlers/advanced.py
+++ b/python-app/handlers/advanced.py
@@ -142,6 +142,7 @@ async def advanced_stage(message: types.Message):
         f'Зайдите в личный Кабинет или зарегестрируйте покупку!',
         reply_markup=kb.lkKeyboard
     )
+    shared_data['photos'] = []
 
 
 def register_advanced_handlers(dp: Dispatcher):

--- a/python-app/handlers/advanced.py
+++ b/python-app/handlers/advanced.py
@@ -91,7 +91,7 @@ async def add_photo_to_queue(file_id: str, message: types.Message, state: FSMCon
             await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
         elif len(data['photos']) == MAX_PHOTOS:
             await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
-            await finalize_photos(message, data)
+            await finalize_photos(message, state, data)
 
 
 async def save_photo_to_storage(file_id: str, message: types.Message) -> str:

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -124,27 +124,21 @@ async def add_photo_to_queue(file_id: str, message: types.Message, state: FSMCon
     """
     Добавляет фото в очередь, проверяет лимит и выполняет финализацию.
     """
-    async with state.proxy() as data:
-        # Инициализируем очередь и сохранённые ссылки
-        if 'photos' not in data:
-            data['photos'] = []
+    # Проверяем лимит
+    if len(shared_data['photos']) >= MAX_PHOTOS:
+        logging.warning(f"Лимит фото достигнут. Игнорируем фото: {file_id}")
+        return
 
-        # Проверяем лимит
-        if len(shared_data['photos']) >= MAX_PHOTOS:
-            logging.warning(f"Лимит фото достигнут. Игнорируем фото: {file_id}")
-            return
+    # Добавляем фото и сохраняем
+    logging.info(f"Добавляем фото: {file_id}")
+    photo_url = await save_photo_to_storage(file_id, message)
+    shared_data['photos'].append(photo_url)
 
-        # Добавляем фото и сохраняем
-        logging.info(f"Добавляем фото: {file_id}")
-        photo_url = await save_photo_to_storage(file_id, message)
-        shared_data['photos'].append(photo_url)
-
-        if len(shared_data['photos']) == 1:
-            await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
-        elif len(shared_data['photos']) == MAX_PHOTOS:
-            await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
-            data['photos'] = shared_data['photos']
-            await finalize_photos(message, state, data)
+    if len(shared_data['photos']) == 1:
+        await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
+    elif len(shared_data['photos']) == MAX_PHOTOS:
+        await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
+        await finalize_photos(message, state)
 
 
 async def save_photo_to_storage(file_id: str, message: types.Message) -> str:
@@ -163,7 +157,7 @@ async def finalize_photos(message: types.Message, state: FSMContext, data: dict)
     Завершает обработку после сохранения двух фото.
     """
     await message.answer("🎉 Спасибо! Обе фотографии загружены и сохранены.")
-    logging.info(f"Финализированные фото: {data['photos']}")
+    logging.info(f"Финализированные фото: {shared_data['photos']}")
     await add_lucky_ticket(message, state)
 
 
@@ -179,7 +173,7 @@ async def add_lucky_ticket(message: types.Message, state: FSMContext):
     )
     async with state.proxy() as data:
         data['lucky_ticket'] = random_string
-    await db.add_item(pool, state, message.from_user.id)
+    await db.add_item(pool, state, shared_data, message.from_user.id)
     await botStages.UserAdvancedScreenplay.advanced.set()
     await advanced_stage(message)
 

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -13,6 +13,7 @@ from handlers.advanced import advanced_stage
 import logging
 import random
 import string
+import re
 
 EMAIL_REGEX = r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
 
@@ -76,6 +77,31 @@ async def add_email(message: types.Message, state: FSMContext):
         )
 
 
+async def add_birthday(message: types.Message, state: FSMContext):
+    async with state.proxy() as data:
+        data['birthday'] = message.text
+    await message.answer(
+        f'Супер!\n'
+        f'Теперь выберите купленный товар и нажмите на кнопку!',
+        reply_markup=kb.productKeyboard
+    )
+    await botStages.UserRegistrationScreenplay.next()
+
+
+async def add_product(message: types.Message, state: FSMContext):
+    async with state.proxy() as data:
+        data['product'] = message.text
+    await message.bot.send_photo(
+        message.chat.id,
+        photo=InputFile('photos/marketplaces.jpg'),
+        caption=f'💖 Оставьте честный отзыв о спрей-гидролат от YARKOST\n'
+                f'📎Прикрепите здесь 2 скрина:\n'
+                f'чек об оплате с маркетплейса и отзыв с артикулом товара, воспользовавшись скрепкой около клавиатуры.',
+        reply_markup=ReplyKeyboardRemove()
+    )
+    await botStages.UserRegistrationScreenplay.next()
+
+
 async def add_photos(message: types.Message, state: FSMContext):
     """
     Обработчик фотографий: вызывает добавление фото через очередь задач.
@@ -130,50 +156,13 @@ async def save_photo_to_storage(file_id: str, message: types.Message) -> str:
     return photo_url
 
 
-async def finalize_photos(message: types.Message, data: dict):
+async def finalize_photos(message: types.Message, state: FSMContext, data: dict):
     """
     Завершает обработку после сохранения двух фото.
     """
     await message.answer("🎉 Спасибо! Обе фотографии загружены и сохранены.")
     logging.info(f"Финализированные фото: {data['photos']}")
-    await add_lucky_ticket(message, FSMContext)
-
-
-async def add_birthday(message: types.Message, state: FSMContext):
-    async with state.proxy() as data:
-        data['birthday'] = message.text
-    await message.answer(
-        f'Супер!\n'
-        f'Теперь выберите купленный товар и нажмите на кнопку!',
-        reply_markup=kb.productKeyboard
-    )
-    await botStages.UserRegistrationScreenplay.next()
-
-
-async def add_product(message: types.Message, state: FSMContext):
-    async with state.proxy() as data:
-        data['product'] = message.text
-    await message.bot.send_photo(
-        message.chat.id,
-        photo=InputFile('photos/marketplaces.jpg'),
-        caption=f'💖 Оставьте честный отзыв о спрей-гидролат от YARKOST\n'
-                f'📎Прикрепите здесь 2 скрина:\n'
-                f'чек об оплате с маркетплейса и отзыв с артикулом товара, воспользовавшись скрепкой около клавиатуры.',
-        reply_markup=ReplyKeyboardRemove()
-    )
-    await botStages.UserRegistrationScreenplay.next()
-
-
-async def dont_added_photo1(message: types.Message):
-    await message.answer(
-        f'Вы не отправили фотографию...😑'
-    )
-
-
-async def dont_added_photo2(message: types.Message):
-    await message.answer(
-        f'Вы не отправили фотографию...😑'
-    )
+    await add_lucky_ticket(message, state)
 
 
 async def add_lucky_ticket(message: types.Message, state: FSMContext):
@@ -202,12 +191,6 @@ def register_registration_handlers(dp: Dispatcher):
     dp.register_message_handler(add_email, state=botStages.UserRegistrationScreenplay.email)
     dp.register_message_handler(add_birthday, state=botStages.UserRegistrationScreenplay.birthday)
     dp.register_message_handler(add_product, state=botStages.UserRegistrationScreenplay.product)
-    # dp.register_message_handler(dont_added_photo1, lambda message: not message.photo,
-    #                             state=botStages.UserRegistrationScreenplay.photo1)
-    # dp.register_message_handler(dont_added_photo2, lambda message: not message.photo,
-    #                             state=botStages.UserRegistrationScreenplay.photo2)
-    # dp.register_message_handler(add_photo1, state=botStages.UserRegistrationScreenplay.photo1, content_types=['photo'])
-    # dp.register_message_handler(add_photo2, state=botStages.UserRegistrationScreenplay.photo2, content_types=['photo'])
     dp.register_message_handler(add_photos, state=botStages.UserRegistrationScreenplay.photo_upload,
                                 content_types=types.ContentType.PHOTO)
     dp.register_message_handler(add_lucky_ticket, state=botStages.UserRegistrationScreenplay.lucky_ticket)

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from aiogram import types, Dispatcher
 from aiogram.dispatcher import FSMContext
 from aiogram.types import ReplyKeyboardRemove
@@ -11,12 +13,11 @@ from handlers.advanced import advanced_stage
 import logging
 import random
 import string
-import re
-from collections import defaultdict
 
 EMAIL_REGEX = r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
 
-photo_groups = defaultdict(list)
+MAX_PHOTOS = 2
+state_lock = asyncio.Lock()
 
 
 async def play(callback_query: types.CallbackQuery):
@@ -75,6 +76,69 @@ async def add_email(message: types.Message, state: FSMContext):
         )
 
 
+async def add_photos(message: types.Message, state: FSMContext):
+    """
+    Обработчик фотографий: вызывает добавление фото через очередь задач.
+    """
+    logging.info(f"Получено сообщение: {message}")
+
+    # Проверяем наличие фото
+    if not message.photo:
+        await message.answer("⚠ Пожалуйста, отправьте фотографию.")
+        return
+
+    file_id = message.photo[-1].file_id
+
+    async with state_lock:  # Блокируем доступ к добавлению фото
+        await add_photo_to_queue(file_id, message, state)
+
+
+async def add_photo_to_queue(file_id: str, message: types.Message, state: FSMContext):
+    """
+    Добавляет фото в очередь, проверяет лимит и выполняет финализацию.
+    """
+    async with state.proxy() as data:
+        # Инициализируем очередь и сохранённые ссылки
+        if 'photos' not in data:
+            data['photos'] = []
+
+        # Проверяем лимит
+        if len(data['photos']) >= MAX_PHOTOS:
+            logging.warning(f"Лимит фото достигнут. Игнорируем фото: {file_id}")
+            return
+
+        # Добавляем фото и сохраняем
+        logging.info(f"Добавляем фото: {file_id}")
+        photo_url = await save_photo_to_storage(file_id, message)
+        data['photos'].append(photo_url)
+
+        if len(data['photos']) == 1:
+            await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
+        elif len(data['photos']) == MAX_PHOTOS:
+            await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
+            await finalize_photos(message, data)
+
+
+async def save_photo_to_storage(file_id: str, message: types.Message) -> str:
+    """
+    Сохраняет фото в хранилище и возвращает ссылку.
+    """
+    random_string = ''.join(random.choices("abcdefghijklmnopqrstuvwxyz0123456789", k=6))
+    filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
+    photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
+    logging.info(f"Фото сохранено на сервере: {photo_url}")
+    return photo_url
+
+
+async def finalize_photos(message: types.Message, data: dict):
+    """
+    Завершает обработку после сохранения двух фото.
+    """
+    await message.answer("🎉 Спасибо! Обе фотографии загружены и сохранены.")
+    logging.info(f"Финализированные фото: {data['photos']}")
+    await add_lucky_ticket(message, FSMContext)
+
+
 async def add_birthday(message: types.Message, state: FSMContext):
     async with state.proxy() as data:
         data['birthday'] = message.text
@@ -110,105 +174,6 @@ async def dont_added_photo2(message: types.Message):
     await message.answer(
         f'Вы не отправили фотографию...😑'
     )
-
-
-# async def add_photo1(message: types.Message, state: FSMContext):
-#     # await state.reset_state(with_data=False)
-#     async with state.proxy() as data:
-#         file_id = message.photo[-1].file_id
-#         random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
-#         filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
-#
-#         photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
-#         current_state = await state.get_state()
-#         await message.answer(f'test1 {current_state}')
-#         if 'photo' not in data:
-#             data['photo'] = []
-#         data['photo'].append(photo_url)
-#     await botStages.UserRegistrationScreenplay.photo2.set()
-#
-#
-# async def add_photo2(message: types.Message, state: FSMContext):
-#     async with state.proxy() as data:
-#         file_id = message.photo[-1].file_id
-#         random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
-#         filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
-#
-#         photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
-#         current_state = await state.get_state()
-#         await message.answer(f'test2 {current_state}')
-#
-#         data['photo'].append(photo_url)
-#
-#     await message.answer(f'test3 {state.get_state()}')
-#
-#     await botStages.UserRegistrationScreenplay.photo2.set()
-
-async def add_photos(message: types.Message, state: FSMContext):
-    logging.info(f"Получено сообщение: {message}")  # Логирование всего сообщения
-
-    async with state.proxy() as data:
-        # Инициализация данных состояния
-        if 'photos' not in data:
-            data['photos'] = []
-        if 'media_group_id' not in data:
-            data['media_group_id'] = None
-
-        # Обработка группированных фото
-        if message.media_group_id:
-            logging.info(f"Обнаружена media_group_id: {message.media_group_id}")
-            photo_groups[message.media_group_id].append(message.photo[-1].file_id)
-
-            # Проверяем, завершена ли группа (Telegram автоматически завершает отправку)
-            if len(photo_groups[message.media_group_id]) >= 2:  # Обрабатываем первую пару фото
-                photos = photo_groups.pop(message.media_group_id)[:2]
-                logging.info(f"Группа завершена, обрабатываем фото: {photos}")
-
-                # Сохраняем фото и отправляем сообщения
-                for i, file_id in enumerate(photos):
-                    photo_url = await save_photo_to_storage(file_id, message)
-                    data['photos'].append(photo_url)
-                    if i == 0:
-                        await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
-                        logging.info(f"Чек сохранен: {photo_url}")
-                    elif i == 1:
-                        await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
-                        logging.info(f"Отзыв сохранен: {photo_url}")
-
-                await finalize_photos(message, data)
-            else:
-                logging.info(f"Фото добавлено в группу: {len(photo_groups[message.media_group_id])}")
-        else:
-            # Обработка одиночного фото
-            logging.info("Обнаружено одиночное фото.")
-            file_id = message.photo[-1].file_id
-            photo_url = await save_photo_to_storage(file_id, message)
-            data['photos'].append(photo_url)
-            if len(data['photos']) == 1:
-                await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
-                logging.info(f"Чек сохранен: {photo_url}")
-            elif len(data['photos']) == 2:
-                await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
-                logging.info(f"Отзыв сохранен: {photo_url}")
-                await finalize_photos(message, data)
-            else:
-                logging.warning("Получено больше 2 фото, игнорируем.")
-
-
-async def save_photo_to_storage(file_id: str, message: types.Message) -> str:
-    """Функция сохранения фото в хранилище."""
-    random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
-    filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
-    photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
-    logging.info(f"Фото сохранено: {photo_url}")
-    return photo_url
-
-
-async def finalize_photos(message: types.Message, data: dict):
-    """Завершение этапа загрузки фотографий."""
-    logging.info(f"Финализируем данные: {data}")
-    await message.answer("Спасибо! Обе фотографии загружены. Начинаю проверку...")
-    await add_lucky_ticket(message, FSMContext)
 
 
 async def add_lucky_ticket(message: types.Message, state: FSMContext):

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -174,6 +174,7 @@ async def add_lucky_ticket(message: types.Message, state: FSMContext):
     async with state.proxy() as data:
         data['lucky_ticket'] = random_string
     await db.add_item(pool, state, shared_data, message.from_user.id)
+    await state.finish()
     await botStages.UserAdvancedScreenplay.advanced.set()
     await advanced_stage(message)
 

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -97,13 +97,19 @@ async def add_product(message: types.Message, state: FSMContext):
     await botStages.UserRegistrationScreenplay.next()
 
 
-async def dont_added_photo(message: types.Message):
+async def dont_added_photo1(message: types.Message):
     await message.answer(
-        f'Вы не отправили фотографии...😑'
+        f'Вы не отправили фотографию...😑'
     )
 
 
-async def add_photo(message: types.Message, state: FSMContext):
+async def dont_added_photo2(message: types.Message):
+    await message.answer(
+        f'Вы не отправили фотографию...😑'
+    )
+
+
+async def add_photo1(message: types.Message, state: FSMContext):
     async with state.proxy() as data:
         file_id = message.photo[-1].file_id
         random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
@@ -111,7 +117,22 @@ async def add_photo(message: types.Message, state: FSMContext):
 
         photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
 
-        data['photo'] = photo_url
+        if 'photo' not in data:
+            data['photo'] = []
+        data['photo'].append(photo_url)
+
+    await botStages.UserRegistrationScreenplay.next()
+
+
+async def add_photo2(message: types.Message, state: FSMContext):
+    async with state.proxy() as data:
+        file_id = message.photo[-1].file_id
+        random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
+        filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
+
+        photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
+
+        data['photo'].append(photo_url)
 
     await botStages.UserRegistrationScreenplay.next()
     await add_lucky_ticket(message, state)
@@ -142,6 +163,8 @@ def register_registration_handlers(dp: Dispatcher):
     dp.register_message_handler(add_email, state=botStages.UserRegistrationScreenplay.email)
     dp.register_message_handler(add_birthday, state=botStages.UserRegistrationScreenplay.birthday)
     dp.register_message_handler(add_product, state=botStages.UserRegistrationScreenplay.product)
-    dp.register_message_handler(dont_added_photo, lambda message: not message.photo, state=botStages.UserRegistrationScreenplay.photo)
-    dp.register_message_handler(add_photo, state=botStages.UserRegistrationScreenplay.photo, content_types=['photo'])
+    dp.register_message_handler(dont_added_photo1, lambda message: not message.photo, state=botStages.UserRegistrationScreenplay.photo1)
+    dp.register_message_handler(dont_added_photo2, lambda message: not message.photo, state=botStages.UserRegistrationScreenplay.photo2)
+    dp.register_message_handler(add_photo1, state=botStages.UserRegistrationScreenplay.photo1, content_types=['photo'])
+    dp.register_message_handler(add_photo2, state=botStages.UserRegistrationScreenplay.photo2, content_types=['photo'])
     dp.register_message_handler(add_lucky_ticket, state=botStages.UserRegistrationScreenplay.lucky_ticket)

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -111,6 +111,7 @@ async def dont_added_photo2(message: types.Message):
 
 
 async def add_photo1(message: types.Message, state: FSMContext):
+    await botStages.UserRegistrationScreenplay.next()
     async with state.proxy() as data:
         file_id = message.photo[-1].file_id
         random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
@@ -121,8 +122,6 @@ async def add_photo1(message: types.Message, state: FSMContext):
         if 'photo' not in data:
             data['photo'] = []
         data['photo'].append(photo_url)
-
-    await botStages.UserRegistrationScreenplay.next()
 
 
 async def add_photo2(message: types.Message, state: FSMContext):

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -125,22 +125,19 @@ async def add_photo1(message: types.Message, state: FSMContext):
 
 
 async def add_photo2(message: types.Message, state: FSMContext):
-    try:
-        async with state.proxy() as data:
-            file_id = message.photo[-1].file_id
-            random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
-            filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
+    async with state.proxy() as data:
+        file_id = message.photo[-1].file_id
+        random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
+        filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
 
-            photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
+        photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
 
-            data['photo'].append(photo_url)
+        data['photo'].append(photo_url)
 
-        await botStages.UserRegistrationScreenplay.next()
-        await add_lucky_ticket(message, state)
-    except Exception as e:
-        await message.answer(
-            f'Произошла ошибка при добавлении фото: {e}'
-        )
+    message.answer(f'{state.get_state()}')
+
+    await botStages.UserRegistrationScreenplay.next()
+    await add_lucky_ticket(message, state)
 
 
 async def add_lucky_ticket(message: types.Message, state: FSMContext):
@@ -156,7 +153,7 @@ async def add_lucky_ticket(message: types.Message, state: FSMContext):
     async with state.proxy() as data:
         data['lucky_ticket'] = random_string
     await db.add_item(pool, state, message.from_user.id)
-    await botStages.UserRegistrationScreenplay.next()
+    await botStages.UserAdvancedScreenplay.advanced.set()
     await advanced_stage(message)
 
 

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -129,15 +129,15 @@ async def add_photo2(message: types.Message, state: FSMContext):
         file_id = message.photo[-1].file_id
         random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
         filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
-
+        await message.answer(f'test {state.get_state()}')
         photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
 
         data['photo'].append(photo_url)
 
-    message.answer(f'{state.get_state()}')
+    await message.answer(f'test2 {state.get_state()}')
 
-    await botStages.UserRegistrationScreenplay.next()
     await add_lucky_ticket(message, state)
+    await botStages.UserRegistrationScreenplay.next()
 
 
 async def add_lucky_ticket(message: types.Message, state: FSMContext):

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -125,17 +125,22 @@ async def add_photo1(message: types.Message, state: FSMContext):
 
 
 async def add_photo2(message: types.Message, state: FSMContext):
-    async with state.proxy() as data:
-        file_id = message.photo[-1].file_id
-        random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
-        filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
+    try:
+        async with state.proxy() as data:
+            file_id = message.photo[-1].file_id
+            random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
+            filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
 
-        photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
+            photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
 
-        data['photo'].append(photo_url)
+            data['photo'].append(photo_url)
 
-    await botStages.UserRegistrationScreenplay.next()
-    await add_lucky_ticket(message, state)
+        await botStages.UserRegistrationScreenplay.next()
+        await add_lucky_ticket(message, state)
+    except Exception as e:
+        await message.answer(
+            f'Произошла ошибка при добавлении фото: {e}'
+        )
 
 
 async def add_lucky_ticket(message: types.Message, state: FSMContext):

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -152,7 +152,7 @@ async def save_photo_to_storage(file_id: str, message: types.Message) -> str:
     return photo_url
 
 
-async def finalize_photos(message: types.Message, state: FSMContext, data: dict):
+async def finalize_photos(message: types.Message, state: FSMContext):
     """
     Завершает обработку после сохранения двух фото.
     """

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -94,7 +94,6 @@ async def add_product(message: types.Message, state: FSMContext):
                 f'чек об оплате с маркетплейса и отзыв с артикулом товара, воспользовавшись скрепкой около клавиатуры.',
         reply_markup=ReplyKeyboardRemove()
     )
-    await message.answer(f'test3 {state.get_state()}')
     await botStages.UserRegistrationScreenplay.next()
 
 
@@ -111,17 +110,18 @@ async def dont_added_photo2(message: types.Message):
 
 
 async def add_photo1(message: types.Message, state: FSMContext):
-    await botStages.UserRegistrationScreenplay.next()
+    await state.reset_state(with_data=False)
     async with state.proxy() as data:
         file_id = message.photo[-1].file_id
         random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
         filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
 
         photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
-        await message.answer(f'test4 {state.get_state()}')
+        await message.answer(f'test1 {state.get_state()}')
         if 'photo' not in data:
             data['photo'] = []
         data['photo'].append(photo_url)
+    await botStages.UserRegistrationScreenplay.photo2.set()
 
 
 async def add_photo2(message: types.Message, state: FSMContext):
@@ -129,12 +129,12 @@ async def add_photo2(message: types.Message, state: FSMContext):
         file_id = message.photo[-1].file_id
         random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
         filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
-        await message.answer(f'test {state.get_state()}')
+        await message.answer(f'tesе2 {state.get_state()}')
         photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
 
         data['photo'].append(photo_url)
 
-    await message.answer(f'test2 {state.get_state()}')
+    await message.answer(f'test3 {state.get_state()}')
 
     await botStages.UserRegistrationScreenplay.next()
     await add_lucky_ticket(message, state)

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -136,9 +136,8 @@ async def add_photo2(message: types.Message, state: FSMContext):
 
     await message.answer(f'test2 {state.get_state()}')
 
-    await add_lucky_ticket(message, state)
     await botStages.UserRegistrationScreenplay.next()
-
+    await add_lucky_ticket(message, state)
 
 async def add_lucky_ticket(message: types.Message, state: FSMContext):
     pool = await message.bot.get('pg_pool')

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -18,6 +18,7 @@ import re
 EMAIL_REGEX = r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
 
 MAX_PHOTOS = 2
+shared_data = {"photos": []}
 state_lock = asyncio.Lock()
 
 
@@ -129,19 +130,20 @@ async def add_photo_to_queue(file_id: str, message: types.Message, state: FSMCon
             data['photos'] = []
 
         # Проверяем лимит
-        if len(data['photos']) >= MAX_PHOTOS:
+        if len(shared_data['photos']) >= MAX_PHOTOS:
             logging.warning(f"Лимит фото достигнут. Игнорируем фото: {file_id}")
             return
 
         # Добавляем фото и сохраняем
         logging.info(f"Добавляем фото: {file_id}")
         photo_url = await save_photo_to_storage(file_id, message)
-        data['photos'].append(photo_url)
+        shared_data['photos'].append(photo_url)
 
-        if len(data['photos']) == 1:
+        if len(shared_data['photos']) == 1:
             await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
-        elif len(data['photos']) == MAX_PHOTOS:
+        elif len(shared_data['photos']) == MAX_PHOTOS:
             await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
+            data['photos'] = shared_data['photos']
             await finalize_photos(message, state, data)
 
 

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -195,4 +195,3 @@ def register_registration_handlers(dp: Dispatcher):
     dp.register_message_handler(add_product, state=botStages.UserRegistrationScreenplay.product)
     dp.register_message_handler(add_photos, state=botStages.UserRegistrationScreenplay.photo_upload,
                                 content_types=types.ContentType.PHOTO)
-    dp.register_message_handler(add_lucky_ticket, state=botStages.UserRegistrationScreenplay.lucky_ticket)

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -142,7 +142,7 @@ async def add_photo_to_queue(file_id: str, message: types.Message, state: FSMCon
             await message.answer("✅ Поздравляю, ваш **чек** сохранён!")
         elif len(data['photos']) == MAX_PHOTOS:
             await message.answer("✅ Поздравляю, ваш **отзыв** сохранён!")
-            await finalize_photos(message, data)
+            await finalize_photos(message, state, data)
 
 
 async def save_photo_to_storage(file_id: str, message: types.Message) -> str:

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -94,6 +94,7 @@ async def add_product(message: types.Message, state: FSMContext):
                 f'чек об оплате с маркетплейса и отзыв с артикулом товара, воспользовавшись скрепкой около клавиатуры.',
         reply_markup=ReplyKeyboardRemove()
     )
+    await message.answer(f'test3 {state.get_state()}')
     await botStages.UserRegistrationScreenplay.next()
 
 
@@ -116,7 +117,7 @@ async def add_photo1(message: types.Message, state: FSMContext):
         filename = f"user_{message.from_user.id}_{random_string}_photo.jpg"
 
         photo_url = await s3.save_photo_to_minio(message.bot, file_id, filename)
-
+        await message.answer(f'test4 {state.get_state()}')
         if 'photo' not in data:
             data['photo'] = []
         data['photo'].append(photo_url)

--- a/python-app/modules/botStages.py
+++ b/python-app/modules/botStages.py
@@ -7,8 +7,7 @@ class UserRegistrationScreenplay(StatesGroup):
     email = State()
     birthday = State()
     product = State()
-    photo1 = State()
-    photo2 = State()
+    photo_upload = State()
     lucky_ticket = State()
 
 

--- a/python-app/modules/botStages.py
+++ b/python-app/modules/botStages.py
@@ -7,9 +7,8 @@ class UserRegistrationScreenplay(StatesGroup):
     email = State()
     birthday = State()
     product = State()
-    photo = State()
-    # photo1 = State()
-    # photo2 = State()
+    photo1 = State()
+    photo2 = State()
     lucky_ticket = State()
 
 

--- a/python-app/modules/botStages.py
+++ b/python-app/modules/botStages.py
@@ -8,14 +8,12 @@ class UserRegistrationScreenplay(StatesGroup):
     birthday = State()
     product = State()
     photo_upload = State()
-    lucky_ticket = State()
 
 
 class UserAdvancedScreenplay(StatesGroup):
     advanced = State()
     advanced_product = State()
     advanced_photo = State()
-    advanced_lucky_ticket = State()
 
 
 class AdminScreenPlay(StatesGroup):


### PR DESCRIPTION
Победа над фотографиями:
1) Фотографии обрабатываются синхронно
2) Обрабатывается только 2 фотографии
3) Если отправлена одна фотография, бот пишет об этом
4) Обработаны случаи с отправкой несгрупированных фото
5) Логику можно подломать, если отправить много несгрупированных фото и успеть зайти "на второй круг" добавления но:
а) Это не сломает бота, просто он сохранит подгружаемые до этого фотографии и сохранит 2
б) Этот вариант работы с ботом уже неадекватный, поэтому проблемы пользователя, который так делает, не учитываются