### PR TITLE
Add readeness probe

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   app:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,10 @@ services:
     env_file:
       - python-app/.env
     depends_on:
-      - pg
-      - minio
+      pg:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
 
   pg:
     image: postgres:15
@@ -21,6 +23,12 @@ services:
       - "5434:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
 
   minio:
     image: minio/minio:RELEASE.2024-11-07T00-52-20Z
@@ -33,6 +41,12 @@ services:
       - "9001:9001"
     volumes:
       - minio_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9000/minio/health/live || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
 
 volumes:
   postgres_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     container_name: yarkostBot
     env_file:
       - python-app/.env
+    restart: always
     depends_on:
       pg:
         condition: service_healthy
@@ -21,6 +22,7 @@ services:
       - "5434:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
       interval: 5s
@@ -39,6 +41,7 @@ services:
       - "9001:9001"
     volumes:
       - minio_data:/data
+    restart: always
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:9000/minio/health/live || exit 1"]
       interval: 5s


### PR DESCRIPTION
1) Добавил healthcheck для pg и minio, который проверяют, готовы ли они принимать запросы (readeness probe)
2) Сделал зависимость для python-app от этих проб, чтобы он не падал при первом запуске
3) Добавил restart: always
4) Апнул docker-compose на своём тестовом серваке, убрал version, согласно новой спецификации docker-compose