### PR TITLE
Blocking documents when processing photos

### DIFF
--- a/python-app/components/s3.py
+++ b/python-app/components/s3.py
@@ -49,7 +49,7 @@ async def save_photo_to_minio(bot, file_id: str, filename: str, user_id: str) ->
             MINIO_BUCKET_NAME,
             object_name,
             photo_path,
-            "image/jpeg"
+            "application/octet-stream"
         )
     finally:
         if os.path.exists(photo_path):

--- a/python-app/components/s3.py
+++ b/python-app/components/s3.py
@@ -49,7 +49,7 @@ async def save_photo_to_minio(bot, file_id: str, filename: str, user_id: str) ->
             MINIO_BUCKET_NAME,
             object_name,
             photo_path,
-            "application/octet-stream"
+            "image/jpg"
         )
     finally:
         if os.path.exists(photo_path):

--- a/python-app/handlers/advanced.py
+++ b/python-app/handlers/advanced.py
@@ -53,6 +53,13 @@ async def additional_product(message: types.Message,  state: FSMContext):
     shared_data['photos'] = []
 
 
+async def processing_document_when_uploading_photo(message: types.Message):
+    await message.reply(
+        f'Пожалуйста, отправьте сжатое фото (поставьте или не убирайте галочку при загрузке на '
+        f'"Сжать изображение") 😶'
+    )
+
+
 async def additional_photo(message: types.Message, state: FSMContext):
     """
     Обработчик фотографий: вызывает добавление фото через очередь задач.
@@ -152,6 +159,9 @@ def register_advanced_handlers(dp: Dispatcher):
     dp.register_message_handler(additional_play, state=botStages.UserAdvancedScreenplay.advanced,
                                 text=['Дополнительный купон'])
     dp.register_message_handler(additional_product, state=botStages.UserAdvancedScreenplay.advanced_product)
+    dp.register_message_handler(processing_document_when_uploading_photo,
+                                state=botStages.UserAdvancedScreenplay.advanced_photo,
+                                content_types=types.ContentType.DOCUMENT)
     dp.register_message_handler(additional_photo, state=botStages.UserAdvancedScreenplay.advanced_photo,
                                 content_types=types.ContentType.PHOTO)
     dp.register_message_handler(advanced_stage, state=botStages.UserAdvancedScreenplay.advanced)

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -147,11 +147,18 @@ async def save_photo_to_storage(file_id: str, message: types.Message) -> str:
     """
     Сохраняет фото в хранилище и возвращает ссылку.
     """
-    file = await message.bot.get_file(file_id)
-    file_extension = os.path.splitext(file.file_path)[1]
-    if not file_extension:
-        mime_type, _ = mimetypes.guess_type(file.file_path)
-        file_extension = mimetypes.guess_extension(mime_type) or ".jpg"
+    mime_type = None
+    if message.document:
+        mime_type = message.document.mime_type
+    elif message.photo:
+        mime_type = "image/jpeg"
+
+    file_extension = None
+    if mime_type:
+        file_extension = mimetypes.guess_extension(mime_type)
+    else:
+        file = await message.bot.get_file(file_id)
+        file_extension = os.path.splitext(file.file_path)[1]
 
     random_string = ''.join(random.choices("abcdefghijklmnopqrstuvwxyz0123456789", k=10))
     filename = f"{random_string}_photo{file_extension}"

--- a/python-app/handlers/registration.py
+++ b/python-app/handlers/registration.py
@@ -10,12 +10,10 @@ from components import keyboards as kb
 from components import s3
 from modules import botStages
 from handlers.advanced import advanced_stage
-import mimetypes
 import logging
 import random
 import string
 import re
-import os
 
 EMAIL_REGEX = r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'
 
@@ -107,8 +105,8 @@ async def add_product(message: types.Message, state: FSMContext):
 
 async def processing_document_when_uploading_photo(message: types.Message):
     await message.reply(
-        f'Пожалуйста, отправьте сжатое фото (поставьте или не убирайте галочку при загрузке на'
-        f'"Сжать изображение")'
+        f'Пожалуйста, отправьте сжатое фото (поставьте или не убирайте галочку при загрузке на '
+        f'"Сжать изображение") 😶'
     )
 
 


### PR DESCRIPTION
Задача из обработки изображений разных расширений переродилась в задачу по блокировнию несжатых изображений.
Причина:
Сжатое изображение будет объектом, который в Telegram всегда будет JPEG.
При этом под document нужно писать отдельно логику и обработчики. Скорее всего, это просто дублирование кода обработки фото, однако, возможно нужно учесть какие файлы относятся к document и обработать непредвиденные ситуации.
На это нет времени.